### PR TITLE
Update module.ts to fix NgxWebstorageModule.forRoot returns a ModuleWithProviders type without a generic type argument

### DIFF
--- a/projects/ngx-webstorage/src/lib/module.ts
+++ b/projects/ngx-webstorage/src/lib/module.ts
@@ -21,7 +21,7 @@ export class NgxWebstorageModule {
 		else console.error('NgxWebstorage : Possible misconfiguration (The forRoot method usage is mandatory since the 3.0.0)');
 	}
 
-	static forRoot(config: NgxWebstorageConfiguration = {}): ModuleWithProviders {
+	static forRoot(config: NgxWebstorageConfiguration = {}): ModuleWithProviders<NgxWebstorageModule> {
 		return {
 			ngModule: NgxWebstorageModule,
 			providers: [


### PR DESCRIPTION
To fix the error:

ERROR in ../node_modules/ngx-webstorage-lppedd/lib/module.d.ts:10:58 - error TS-996005: NgxWebstorageModule.forRoot returns a ModuleWithProviders type without a generic type argument. Please add a generic type argument to the ModuleWithProviders type. If this occurrence is in library code you don't control, please contact the library authors.